### PR TITLE
fix content overlay issue in signupform.html

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -371,7 +371,7 @@ footer {
   border-radius: 10px;
   max-width: 800px;
   width: 100%;
-  margin: 50px auto;
+  margin: 150px auto;
 }
 .signup-form-contain .formheading {
   text-align: center;

--- a/less/signupform.less
+++ b/less/signupform.less
@@ -3,7 +3,7 @@
   border-radius: 10px;
   max-width: 800px;
   width: 100%;
-  margin: 50px auto;
+  margin: 150px auto;
 
   .formheading {
     text-align: center;


### PR DESCRIPTION
- Fixed content overlay issue inside of signupform.html
- - When the desktop display is active, the nav menu was overlaying the page content - SOLVED by adding top margin to the content container directly below the nav menu